### PR TITLE
Fix sample rate handling in VAD segmenter

### DIFF
--- a/asr/server.py
+++ b/asr/server.py
@@ -55,7 +55,7 @@ class Segmenter:
             return None
         is_speech = False
         try:
-            is_speech = self.vad.is_speech(frame, sample_rate=16000)
+            is_speech = self.vad.is_speech(frame, sample_rate=self.sr)
         except Exception:
             pass
         if not self.in_speech:

--- a/tests/test_segmenter.py
+++ b/tests/test_segmenter.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from asr.server import Segmenter
+
+
+def generate_pcm(sr: int, speech_duration: float = 1.0, silence_duration: float = 1.0) -> bytes:
+    t = np.arange(int(sr * speech_duration), dtype=np.float32) / sr
+    speech = 0.5 * np.sin(2 * np.pi * 440 * t)
+    speech_pcm = (speech * 32767).astype(np.int16)
+    silence_pcm = np.zeros(int(sr * silence_duration), dtype=np.int16)
+    audio = np.concatenate([speech_pcm, silence_pcm])
+    return audio.tobytes()
+
+
+def feed_audio(seg: Segmenter, pcm: bytes):
+    out = None
+    frame_bytes = seg.frame_bytes
+    for i in range(0, len(pcm) - (len(pcm) % frame_bytes), frame_bytes):
+        frame = pcm[i : i + frame_bytes]
+        out = seg.push(frame)
+        if out is not None:
+            break
+    return out
+
+
+def _assert_detects(sr: int):
+    seg = Segmenter(sr=sr)
+    pcm = generate_pcm(sr)
+    out = feed_audio(seg, pcm)
+    assert out is not None
+    audio = np.frombuffer(out, dtype=np.int16)
+    # ensure there is speech content (non-zero amplitude)
+    assert np.max(np.abs(audio)) > 0
+
+
+def test_segmenter_detects_8kHz_and_16kHz():
+    _assert_detects(8000)
+    _assert_detects(16000)


### PR DESCRIPTION
## Summary
- use the segmenter's configured sample rate when running WebRTC VAD
- add unit test covering silence detection at 8kHz and 16kHz

## Testing
- `pytest tests/test_segmenter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b5c72b0483219ee049142216f93e